### PR TITLE
Fixd bug that didn't allow none English configured operating systems to parse .publishsettings file

### DIFF
--- a/AzureFluentManagement.sln
+++ b/AzureFluentManagement.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastacloud.AzureManagement.Fluent", "Elastacloud.AzureManagement.Fluent\Elastacloud.AzureManagement.Fluent.csproj", "{6119D185-70B4-4137-97ED-876A30E0850B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastacloud.AzureManagement.Fluent.Tests", "Elastacloud.AzureManagement.Fluent.Tests\Elastacloud.AzureManagement.Fluent.Tests.csproj", "{B494A1C5-3612-43AE-BC60-942FCFB2AE7C}"
@@ -53,8 +55,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
 	EndGlobalSection
 EndGlobal

--- a/Elastacloud.AzureManagement.Fluent.Tests/TestPublishSettings.cs
+++ b/Elastacloud.AzureManagement.Fluent.Tests/TestPublishSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Globalization;
+using System.IO;
+using System.Threading;
 using Elastacloud.AzureManagement.Fluent.Helpers.PublishSettings;
 using NUnit.Framework;
 using FluentAssertions;
@@ -70,10 +72,23 @@ namespace Elastacloud.AzureManagement.Fluent.Tests
 		[Test]
 		public void TestVersion2Schema()
 		{
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");
+
 			var settings = PublishSettingsExtractor.GetFromXml(V2);
 			var dictionary = settings.GetSubscriptions();
 			dictionary.Count.Should().Be(1, "Number of subscriptions in Xml .publishsettings string");
 			settings.SchemaVersion.Should().Be(2, "the schema number used");
 		}
+
+        [Test]
+        public void TestVersion2SchemaWithForeginCultureSettings()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("sv-SE");
+
+            var settings = PublishSettingsExtractor.GetFromXml(V2);
+            var dictionary = settings.GetSubscriptions();
+            dictionary.Count.Should().Be(1, "Number of subscriptions in Xml .publishsettings string");
+            settings.SchemaVersion.Should().Be(2, "the schema number used");
+        }
 	}
 }

--- a/Elastacloud.AzureManagement.Fluent/Helpers/PublishSettings/PublishSettingsExtractor.cs
+++ b/Elastacloud.AzureManagement.Fluent/Helpers/PublishSettings/PublishSettingsExtractor.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -81,7 +82,7 @@ namespace Elastacloud.AzureManagement.Fluent.Helpers.PublishSettings
         {
             var schemaAttrs = _publishSettingsFileXml.Descendants("PublishProfile").FirstOrDefault().Attributes("SchemaVersion");
             var containsSchema = schemaAttrs.Any();
-            SchemaVersion = containsSchema ? (int)double.Parse(schemaAttrs.FirstOrDefault().Value) : 1D;
+            SchemaVersion = containsSchema ? (int)double.Parse(schemaAttrs.FirstOrDefault().Value, CultureInfo.InvariantCulture) : 1D;
 
             _subscriptions = _publishSettingsFileXml.Descendants("Subscription").Select(a => new Subscription()
                                                                     { 


### PR DESCRIPTION
Parsing a string like "2.0" as a double using .NET Framework will only work on operating systems where "dot" has been configured as decimal separator or if you specify a specific CultureInfo that uses "dot" as decimal separator.

This causes the parsing of the .publishsettings to fail on operating systems configured to use other decimal separatorns. For example: the Nordic Countries uses "comma" as decimal separator, hence can't use the Windows Azure Fluent Management without using workarounds.

This pull request contains a simple fix to the problem as well as updated unit tests to show that the problem did exists as well as that it has been solved.

(Also used Visual Studio 2013 to compile and test the project with success)
